### PR TITLE
Add workflow to trigger KB wrapper build on master push

### DIFF
--- a/.github/workflows/trigger-kb-build.yml
+++ b/.github/workflows/trigger-kb-build.yml
@@ -9,31 +9,29 @@ jobs:
   trigger-build:
     runs-on: ubuntu-latest
     steps:
-      - name: Get commit info
-        id: commit
-        run: |
-          echo "author_name=${{ github.event.head_commit.author.name }}" >> "$GITHUB_OUTPUT"
-          echo "author_email=${{ github.event.head_commit.author.email }}" >> "$GITHUB_OUTPUT"
-          echo "commit_message=${{ github.event.head_commit.message }}" >> "$GITHUB_OUTPUT"
-          echo "commit_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-          echo "commit_url=${{ github.event.head_commit.url }}" >> "$GITHUB_OUTPUT"
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.KB_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.KB_DISPATCH_APP_PRIVATE_KEY }}
+          owner: AdGuardSoftwareLimited
+          repositories: knowledge-base-wrapper
 
       - name: Trigger knowledge-base-wrapper build
         run: |
           curl -f -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.KB_WRAPPER_DISPATCH_TOKEN }}" \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
             https://api.github.com/repos/AdGuardSoftwareLimited/knowledge-base-wrapper/dispatches \
             -d '{
               "event_type": "build",
               "client_payload": {
                 "app": "mail",
-                "kb_repo": "AdguardTeam/KnowledgeBaseMail",
-                "domain": "adguard-mail.com",
                 "commit_sha": "${{ github.sha }}",
-                "author_name": "${{ steps.commit.outputs.author_name }}",
-                "author_email": "${{ steps.commit.outputs.author_email }}",
-                "commit_message": "${{ steps.commit.outputs.commit_message }}",
+                "author_name": "${{ github.event.head_commit.author.name }}",
+                "author_email": "${{ github.event.head_commit.author.email }}",
+                "commit_message": "${{ github.event.head_commit.message }}",
                 "commit_url": "${{ github.event.head_commit.url }}"
               }
             }'

--- a/.github/workflows/trigger-kb-build.yml
+++ b/.github/workflows/trigger-kb-build.yml
@@ -1,0 +1,39 @@
+name: Trigger KB Wrapper Build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  trigger-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get commit info
+        id: commit
+        run: |
+          echo "author_name=${{ github.event.head_commit.author.name }}" >> "$GITHUB_OUTPUT"
+          echo "author_email=${{ github.event.head_commit.author.email }}" >> "$GITHUB_OUTPUT"
+          echo "commit_message=${{ github.event.head_commit.message }}" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "commit_url=${{ github.event.head_commit.url }}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger knowledge-base-wrapper build
+        run: |
+          curl -f -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.KB_WRAPPER_DISPATCH_TOKEN }}" \
+            https://api.github.com/repos/AdGuardSoftwareLimited/knowledge-base-wrapper/dispatches \
+            -d '{
+              "event_type": "build",
+              "client_payload": {
+                "app": "mail",
+                "kb_repo": "AdguardTeam/KnowledgeBaseMail",
+                "domain": "adguard-mail.com",
+                "commit_sha": "${{ github.sha }}",
+                "author_name": "${{ steps.commit.outputs.author_name }}",
+                "author_email": "${{ steps.commit.outputs.author_email }}",
+                "commit_message": "${{ steps.commit.outputs.commit_message }}",
+                "commit_url": "${{ github.event.head_commit.url }}"
+              }
+            }'


### PR DESCRIPTION
Adds a new workflow that triggers the `knowledge-base-wrapper` build via `repository_dispatch` whenever changes are pushed to `master`.

### What it does
- On push to `master`, sends a `repository_dispatch` event to `AdGuardSoftwareLimited/knowledge-base-wrapper` with:
  - `app`: `mail`
  - `kb_repo`: `AdguardTeam/KnowledgeBaseMail`
  - `domain`: `adguard-mail.com`
  - `commit_sha`: the pushed commit SHA
  - Author name, email, commit message, and commit URL

### Required setup
- A secret `KB_WRAPPER_DISPATCH_TOKEN` must be added to this repo — a GitHub PAT with `repo` scope that has access to `AdGuardSoftwareLimited/knowledge-base-wrapper`.